### PR TITLE
Fix NPE when FileTarget hasn't been used

### DIFF
--- a/CoreTechs.Logging/Targets/FileTarget.cs
+++ b/CoreTechs.Logging/Targets/FileTarget.cs
@@ -128,7 +128,8 @@ namespace CoreTechs.Logging.Targets
 
         public void Dispose()
         {
-            _logFile.Dispose();
+            if(_logFile != null)
+                _logFile.Dispose();
         }
     }
 }


### PR DESCRIPTION
If a file target is never written to (for example, if the FileTarget has
been set to a level that hasn't been logged to), _logFile will be null
on dispose. This can interrupt other Targets' disposing.
